### PR TITLE
Adding ALB Support Out of the Box.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -5,6 +5,9 @@ error_reporting(E_ALL | E_STRICT);
 
 $AWS_LAMBDA_RUNTIME_API = getenv('AWS_LAMBDA_RUNTIME_API');
 
+/* https://gist.github.com/henriquemoody/6580488 */
+$http_codes = [100=>'Continue',101=>'Switching Protocols',102=>'Processing',200=>'OK',201=>'Created',202=>'Accepted',203=>'Non-Authoritative Information',204=>'No Content',205=>'Reset Content',206=>'Partial Content',207=>'Multi-Status',208=>'Already Reported',226=>'IM Used',300=>'Multiple Choices',301=>'Moved Permanently',302=>'Found',303=>'See Other',304=>'Not Modified',305=>'Use Proxy',306=>'Switch Proxy',307=>'Temporary Redirect',308=>'Permanent Redirect',400=>'Bad Request',401=>'Unauthorized',402=>'Payment Required',403=>'Forbidden',404=>'Not Found',405=>'Method Not Allowed',406=>'Not Acceptable',407=>'Proxy Authentication Required',408=>'Request Timeout',409=>'Conflict',410=>'Gone',411=>'Length Required',412=>'Precondition Failed',413=>'Request Entity Too Large',414=>'Request-URI Too Long',415=>'Unsupported Media Type',416=>'Requested Range Not Satisfiable',417=>'Expectation Failed',418=>'I\'m a teapot',419=>'Authentication Timeout',420=>'Enhance Your Calm',420=>'Method Failure',422=>'Unprocessable Entity',423=>'Locked',424=>'Failed Dependency',424=>'Method Failure',425=>'Unordered Collection',426=>'Upgrade Required',428=>'Precondition Required',429=>'Too Many Requests',431=>'Request Header Fields Too Large',444=>'No Response',449=>'Retry With',450=>'Blocked by Windows Parental Controls',451=>'Redirect',451=>'Unavailable For Legal Reasons',494=>'Request Header Too Large',495=>'Cert Error',496=>'No Cert',497=>'HTTP to HTTPS',499=>'Client Closed Request',500=>'Internal Server Error',501=>'Not Implemented',502=>'Bad Gateway',503=>'Service Unavailable',504=>'Gateway Timeout',505=>'HTTP Version Not Supported',506=>'Variant Also Negotiates',507=>'Insufficient Storage',508=>'Loop Detected',509=>'Bandwidth Limit Exceeded',510=>'Not Extended',511=>'Network Authentication Required',598=>'Network read timeout error',599=>'Network connect timeout error'];
+
 function start_webserver() {
   $pid = pcntl_fork();
   switch($pid) {
@@ -137,7 +140,7 @@ while (true) {
         array_push($headers, "${name}: ${value}");
       }
     }
-    
+
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
   }
 
@@ -202,16 +205,22 @@ while (true) {
 
   $ch = curl_init("http://$AWS_LAMBDA_RUNTIME_API/2018-06-01/runtime/invocation/$invocation_id/response");
 
+  $isALB = array_key_exists("elb", $event['requestContext']);
+  if ($isALB) { // Add Headers For ALB
+    $status = $response["statusCode"];
+    $response["statusDescription"] = "$status ". $http_codes[$status];
+    $response["isBase64Encoded"] = false;
+  }
   $response_json = json_encode($response);
-
   curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
   curl_setopt($ch, CURLOPT_POSTFIELDS, $response_json);
-  curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-    'Content-Type: application/json',
-    'Content-Length: ' . strlen($response_json)
-  ));
-
+  if (!$isALB){
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+      'Content-Type: application/json',
+      'Content-Length: ' . strlen($response_json)
+    ));
+  }
   curl_exec($ch);
   curl_close($ch);
 }

--- a/bootstrap
+++ b/bootstrap
@@ -208,7 +208,11 @@ while (true) {
   $isALB = array_key_exists("elb", $event['requestContext']);
   if ($isALB) { // Add Headers For ALB
     $status = $response["statusCode"];
-    $response["statusDescription"] = "$status ". $http_codes[$status];
+    if (array_key_exists($status, $http_codes)) {
+        $response["statusDescription"] = "$status ". $http_codes[$status];
+    } else {
+        $response["statusDescription"] = "$status Unknown";
+    }
     $response["isBase64Encoded"] = false;
   }
   $response_json = json_encode($response);


### PR DESCRIPTION
Adding Support for PHP to output directly to an ALB

Checked Here:
https://aws.amazon.com/pt/blogs/networking-and-content-delivery/lambda-functions-as-targets-for-application-load-balancers/

We need to add isBase64Encoded= false and the statusDescription to the Response in order to ALB to accepts it as a valid response and not give us 502.

The problem is that if we always add, Api Gateway complains and throws us an error :)

With this little code, everything works seamlessly(with multiValueHeaders enabled in the ELB Target group) without the user have the need to worry. It  supports Api Gateway + ALB (If someone want to do some endpoints in ALB directly to save some Api Gateway Requests) 

Hope you enjoy

