### PR TITLE
Allow layers to load extra ini files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ extension=json.so
 
 Extensions can be built using the lambci/lambda:build-nodejs8.10 Docker image. It is recommended that custom extensions be provided by a separate Lambda Layer with the extension .so files placed in /lib/php/7.1/modules/ so they can be loaded alongside the built-in extensions listed above.
 
-#### Example
+The extensions can be loaded by adding an ini file in the etc/php-7.1.d this will be picked up automatically
+
+#### SAM Example
 Let's create an AWS SAM PHP application. We suggest using [Stackery](https://stackery.io) to make this super simple. It automates all the scaffolding shown below. But you may also choose to roll your own application from scratch.
 
 First, install [AWS SAM CLI](https://github.com/awslabs/aws-sam-cli). Make sure to create a SAM deployment bucket as shown in [Packaging your application](https://github.com/awslabs/aws-sam-cli/blob/develop/docs/deploying_serverless_applications.rst#packaging-your-application)

--- a/bootstrap
+++ b/bootstrap
@@ -15,7 +15,7 @@ function start_webserver() {
       // exec the command
       $HANDLER = getenv('_HANDLER');
       chdir('/var/task');
-      exec("php -S localhost:8000 -c /var/task/php.ini -d extension_dir=/opt/lib/php/7.1/modules '$HANDLER'");
+      exec("PHP_INI_SCAN_DIR=/opt/etc/php-7.1.d/:/var/task/php-7.1.d/ php -S localhost:8000 -c /var/task/php.ini -d extension_dir=/opt/lib/php/7.1/modules '$HANDLER'");
       exit;
 
     // return the child pid to parent
@@ -137,7 +137,7 @@ while (true) {
         array_push($headers, "${name}: ${value}");
       }
     }
-    
+
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
   }
 


### PR DESCRIPTION
When you create new layers which would load additional extensions you need to be able to load extra ini files. This change will enable this in an easy way. Futhermore this will also enable lambda function to create their own php.ini overrides

For Layers:
Layers should add ini files to etc/php-7.1.d in the zip file it will be automatically be picked up during the bootstrap

For Lambda:
Add you custom ini files to /php-7.1.d and the bootstrap will apply them. 