### PR TITLE
Fix value of `PHP_SELF` when router script is in a subdirectory

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -17,8 +17,11 @@ function start_webserver() {
     case 0:
       // exec the command
       $HANDLER = getenv('_HANDLER');
-      chdir('/var/task');
-      exec("PHP_INI_SCAN_DIR=/opt/etc/php-7.1.d/:/var/task/php-7.1.d/ php -S localhost:8000 -c /var/task/php.ini -d extension_dir=/opt/lib/php/7.1/modules '$HANDLER'");
+      $handler_components = explode('/', $HANDLER);
+      $handler_filename = array_pop($handler_components);
+      $handler_path = implode('/', array_merge(['/var/task'], $handler_components));
+      chdir($handler_path);
+      exec("PHP_INI_SCAN_DIR=/opt/etc/php-7.1.d/:/var/task/php-7.1.d/ php -S localhost:8000 -c /var/task/php.ini -d extension_dir=/opt/lib/php/7.1/modules '$handler_filename'");
       exit;
 
     // return the child pid to parent


### PR DESCRIPTION
PHP's built-in web server sets the value of `$_SERVER['PHP_SELF']` differently when the router script is in working directory versus a subdirectory of the working directory. This breaks routing functionality in routing libraries such as [Slim](https://www.slimframework.com).

When the script is in the working directory, the value of `PHP_SELF` is the filename of the script, but when run from a parent directory of the script it changes to being the path requested of the web server.

This commit changes `bootstrap` behaviour when referring to the Lambda handler. If it refers to a script in a subdirectory of the task root, it changes the `chdir` call to enter that directory before running the PHP internal web-server, so that it can refer to the script filename as being in the working directory.

This poses no change to how the layer is configured or run, but `PHP_SELF` now correctly refers to the filename and this solves the issue with Slim.

Resolves: stackery/php-lambda-layer#11