### PR TITLE
Allow binary content to be returned from PHP

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -231,7 +231,8 @@ while (true) {
     } else {
         $response["statusDescription"] = "$status Unknown";
     }
-    $response["isBase64Encoded"] = false;
+    $response["body"] = base64_encode($response["body"]);
+    $response["isBase64Encoded"] = true;
   }
   $response_json = json_encode($response);
   curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');


### PR DESCRIPTION
To return Binary content through the ALB, it needs to be Base64 Encoded and the isBase64Encoded flag needs to be set to true.

This change Base64 encodes all responses, and sets the isBase64Encoded flag to true, so that both plaintext and binary responses work.