### PR TITLE
[PHP 7.3] fixed issue with installing remi repo and added missing PHP extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ bz2.so
 calendar.so
 ctype.so
 curl.so
+dom.so
 exif.so
 fileinfo.so
 ftp.so
@@ -52,15 +53,26 @@ json.so
 mbstring.so
 mysqli.so
 mysqlnd.so
-pdo.so
 pdo_mysql.so
 pdo_pgsql.so
+pdo.so
 pdo_sqlite.so
 pgsql.so
 phar.so
+posix.so
+shmop.so
+simplexml.so
 sockets.so
 sqlite3.so
+sysvmsg.so
+sysvsem.so
+sysvshm.so
 tokenizer.so
+wddx.so
+xmlreader.so
+xml.so
+xmlwriter.so
+xsl.so
 ```
 
 PHP 7.1 Layer:

--- a/build-php-remi.sh
+++ b/build-php-remi.sh
@@ -8,9 +8,8 @@ yum install -y wget
 yum install -y yum-utils
 wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 wget https://rpms.remirepo.net/enterprise/remi-release-6.rpm
-rpm -Uvh remi-release-6.rpm
 rpm -Uvh epel-release-latest-6.noarch.rpm
-
+rpm -Uvh remi-release-6.rpm
 
 yum-config-manager --enable remi-php7${PHP_MINOR_VERSION}
 
@@ -18,7 +17,7 @@ yum install -y httpd
 yum install -y postgresql-devel
 yum install -y libargon2-devel
 
-yum install -y --disablerepo="*" --enablerepo="remi,remi-php7${PHP_MINOR_VERSION}" php php-mbstring php-pdo php-mysql php-pgsql
+yum install -y --disablerepo="*" --enablerepo="remi,remi-php7${PHP_MINOR_VERSION}" php php-mbstring php-pdo php-mysql php-pgsql php-xml php-process
 
 
 mkdir /tmp/layer


### PR DESCRIPTION
This PR, fixes issue #38 

In the end, it was a small fix. When building the php73.zip there were errors in installing remi repo, and it all came down to the order we installed epel and remi, reverting those instructions fixed the problem.

In term of adding the missing extensions required by Symfony 4, I only had to add php-xml and php-process to the list of php packages to be installed.

I tested and deployed the generated layer. phpinfo can be seen [here](https://3crp2q2q4l.execute-api.ap-southeast-2.amazonaws.com/Prod/home) (this page will be deleted once we merge this PR).

**Side note:** I did not explore, but I wonder why do we need to install httpd as part of building the image?! In my case, I'm using API Gateway to handle the requests and fire the lambda. I might be missing something but I do not think we need apache.
