### PR TITLE
Fix redirecting from PHP

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -145,7 +145,7 @@ while (true) {
 
   $ch = curl_init("http://localhost:8000$uri");
 
-  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, FALSE);
 
   if (array_key_exists('multiValueHeaders', $event)) {
     $headers = array();


### PR DESCRIPTION
By following redirects to the local PHP server inside Lambda, the function will return an invalid response. This fix will not follow redirects, so only the 30X response will be returned to API Gateway.