### PR TITLE
Add libonig.so.5 for mbstring

### DIFF
--- a/build-php-remi.sh
+++ b/build-php-remi.sh
@@ -37,6 +37,7 @@ done
 cp /usr/lib64/libedit.so.0 lib/
 cp /usr/lib64/libargon2.so.0 lib/
 cp /usr/lib64/libpq.so.5 lib/
+cp /usr/lib64/libonig.so.5 lib/
 
 mkdir -p lib/php/7.${PHP_MINOR_VERSION}
 cp -a /usr/lib64/php/modules lib/php/7.${PHP_MINOR_VERSION}/


### PR DESCRIPTION
When building and pushing the layer zip locally, I had to copy `libonig.so.5` to the lib dir manually for the `mbstring` module to load. `mbstring` loaded without errors on the publicly posted version ( I tested `arn:aws:lambda:us-west-2:887080169480:layer:php73:2` )... Any ideas?

(By the way, I haven't tested the other PHP version yet (`build.sh`), I'll try that out when I have a bit more time)