### PR TITLE
Send body regardless of what the HTTP method is.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -171,13 +171,7 @@ while (true) {
   }
 
   if (strlen($body) > 0) {
-    if($event['httpMethod'] === 'POST'){
-      curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
-    }    
-    curl_setopt($ch, CURLOPT_INFILESIZE, strlen($body));
-    curl_setopt($ch, CURLOPT_READFUNCTION, function ($ch, $fd, $length) use ($body) {
-      return $body;
-    });
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
   }
 
   $response = array();

--- a/build-php-remi.sh
+++ b/build-php-remi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 PHP_MINOR_VERSION=$1
 


### PR DESCRIPTION
This allows PUT and PATCH requests, for example. This could be also accomplished by using a whitelist of HTTP methods where the request body should also be forwarded, but I think that's a little more error-prone than just sending everything. If it's really a bad request, it should be filtered by API Gateway or ALB anyways.

(I also added `-e` to the build script, because it was failing midway but still continuing. I see that the specific error I was encountering has already been fixed in master, is there a chance we can merge master back to development soon?)