### PR TITLE
Update extension order

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,14 @@ json.so
 mbstring.so
 mysqlnd.so
 mysqli.so
+pdo.so
 pdo_mysql.so
 pdo_pgsql.so
-pdo.so
 pdo_sqlite.so
 pgsql.so
 phar.so
 posix.so
 shmop.so
-simplexml.so
 sockets.so
 sqlite3.so
 sysvmsg.so
@@ -69,9 +68,10 @@ sysvsem.so
 sysvshm.so
 tokenizer.so
 wddx.so
-xmlreader.so
 xml.so
+xmlreader.so
 xmlwriter.so
+simplexml.so
 xsl.so
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ gettext.so
 iconv.so
 json.so
 mbstring.so
-mysqli.so
 mysqlnd.so
+mysqli.so
 pdo_mysql.so
 pdo_pgsql.so
 pdo.so

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ sysvmsg.so
 sysvsem.so
 sysvshm.so
 tokenizer.so
-wddx.so
 xml.so
 xmlreader.so
 xmlwriter.so
 simplexml.so
 xsl.so
+wddx.so
 ```
 
 PHP 7.1 Layer:


### PR DESCRIPTION
`mysqli` requires `mysqlnd` to be loaded before it can be loaded. This change make copy paste easier and would've saved me two hours.

Credits: https://github.com/stackery/php-lambda-layer/issues/37#issuecomment-493391862