### PR TITLE
encode url params

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -134,10 +134,10 @@ while (true) {
           $uri .= "&";
         }
 
-        $uri .= $name;
+        $uri .= rawurlencode($name);
 
         if ($value != '') {
-          $uri .= '=' . $value;
+          $uri .= '=' . rawurlencode($value);
         }
       }
     }

--- a/bootstrap
+++ b/bootstrap
@@ -134,10 +134,10 @@ while (true) {
           $uri .= "&";
         }
 
-        $uri .= rawurlencode($name);
+        $uri .= rawurlencode($name) . '=';
 
         if ($value != '') {
-          $uri .= '=' . rawurlencode($value);
+          $uri .= rawurlencode($value);
         }
       }
     }


### PR DESCRIPTION
Request: http://localhost/?param1=%23w0-pjax produces wrong url when passing forward to lambda. Value "#" should be encoded